### PR TITLE
Rolled back to 0.29.0 python API client until it is fixed for 0.30.0 core release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 googleapis-common-protos==1.52.0
 grpcio==1.35.0
 requests==2.25.1
-Vega-API-client==0.30.0
+Vega-API-client==0.29.0
 websocket-client==0.57.0

--- a/stream-events/stream-events-with-Vega-API-client.py
+++ b/stream-events/stream-events-with-Vega-API-client.py
@@ -19,6 +19,7 @@ Apps/Libraries:
 # some code here
 # :something__
 
+import queue
 import os
 import signal
 import sys
@@ -50,13 +51,18 @@ print("Connecting to stream...")
 
 # __stream_events:
 # Subscribe to the events bus stream for the marketID specified
-# Required: type field - default ALL
+# Required: type field - A collection of one or more event types e.g. BUS_EVENT_TYPE_ORDER.
+# Required: batchSize field - Default: 0 - Total number of events to batch on server before sending to client.
 # Optional: Market identifier - filter by market
 #           Party identifier - filter by party
 # By default, all events on all markets for all parties will be returned on the stream.
-all_types = vac.events.BUS_EVENT_TYPE_ALL
-subscribe_events_request = vac.api.trading.ObserveEventsRequest(type=[all_types], marketID=market_id)
-for stream_resp in data_client.ObserveEventBus(subscribe_events_request):
+# e.g. all_types = vac.events.BUS_EVENT_TYPE_ALL
+event_types = vac.events.BUS_EVENT_TYPE_TRADE
+subscribe_events_request = vac.api.trading.ObserveEventsRequest(batchSize=0, type=[event_types], marketID=market_id)
+send_queue = queue.SimpleQueue()
+stream = data_client.ObserveEventBus(iter(send_queue.get, None))
+send_queue.put_nowait(subscribe_events_request)
+for stream_resp in stream:
     for events in stream_resp.events:
         # All events (as per request filter) arriving over the channel/stream will be printed
         print(events)


### PR DESCRIPTION
* Rolled back python gRPC API client to 0.29.0 version in requirements.txt
* Updated streaming events example to use a queue