### PR TITLE
Switch over to v1/command usage for samples

### DIFF
--- a/get-assets/get-assets.py
+++ b/get-assets/get-assets.py
@@ -42,7 +42,7 @@ print("Assets:\n{}".format(
 found_asset_id = "UNKNOWN"
 assets = response.json()["assets"]
 for asset in assets:
-    if asset["symbol"] == "tDAI":
+    if asset["details"]["symbol"] == "tDAI":
         print()
         print("Found an asset with symbol tDAI:")
         found_asset_id = asset["id"]

--- a/propose-markets/propose-vote-enact-market.py
+++ b/propose-markets/propose-vote-enact-market.py
@@ -344,7 +344,7 @@ assert proposal_id != ""
 # https://docs.testnet.vega.xyz/docs/api-howtos/proposals/
 
 # __prepare_vote:
-# Prepare a vote for the proposal
+# Create a vote message, to vote on the proposal
 vote = {
     "voteSubmission": {
         "value": "VALUE_YES",  # Can be either VALUE_YES or VALUE_NO

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 googleapis-common-protos==1.52.0
 grpcio==1.35.0
 requests==2.25.1
-Vega-API-client==0.36.0
+Vega-API-client==0.38.0
 websocket-client==0.57.0

--- a/stream-orders-by-reference/stream-orders-with-Vega-API-client.py
+++ b/stream-orders-by-reference/stream-orders-with-Vega-API-client.py
@@ -42,8 +42,6 @@ data_client = vac.VegaTradingDataClient(node_url_grpc)
 
 # __stream_orders_by_ref:
 # Stream orders by reference on a Vega network
-# Note: This is an example and order reference will be provided in the response
-# from a prepareSubmitOrder request in the field named `submitID` or similar.
 reference = "4617844f-6fab-4cf6-8852-e29dbd96e5f1"
 pubkey = "94c21a5bfc212c0b4ee6e3593e8481559972ad31f1fb453491f255e72bdb6fdb"
 subscribe_request = vac.api.trading.OrdersSubscribeRequest(party_id=pubkey)

--- a/stream-orders-by-reference/stream-orders.sh
+++ b/stream-orders-by-reference/stream-orders.sh
@@ -23,8 +23,6 @@ check_url "NODE_URL_GRAPHQL" || exit 1
 
 # __stream_orders_by_ref:
 # Stream orders by reference on a Vega network
-# Note: This is an example and order reference will be provided in the response
-# from a prepareSubmitOrder request in the field named `submitID` or similar.
 reference="4617844f-6fab-4cf6-8852-e29dbd96e5f1"
 pubkey="94c21a5bfc212c0b4ee6e3593e8481559972ad31f1fb453491f255e72bdb6fdb"
 gq $NODE_URL_GRAPHQL -q 'subscription { orders(partyId: "'$pubkey'") { id, reference } }'

--- a/submit-amend-cancel-orders/response-examples.txt
+++ b/submit-amend-cancel-orders/response-examples.txt
@@ -1,80 +1,46 @@
-### __example_prepare_submit_order_response:
-# Response for preparing a submit order message
-{
-  "blob": "YWQ5M2NmYzktYTU5OC00MmNmLTk4ZmMtOTA1NWY0MWUzMTBmQBI ... mItZjA4NDllOTY1YzIy",
-  "submitID": "50f790bc-c1c6-47fd-a52b-f0849e965c22"
-}
-# Note: some fields have been shortened to improve readability
-### :example_prepare_submit_order_response__
-
-
 ### __example_sign_tx_response:
-# Response for signing the prepared transaction
+# Response for signing the transaction
 {
-  "base64Bundle": "CvQBCsMBNzYwMWUxMjUtYzZiMC00ZGRjLWIzZTQt6SDC ... 2ZWdhL2VkMjU1MTkYAQ==",
-  "hexBundle": "0af4010ac30137363031653132352d63366230 ... db907120c766567612f656432353531391801",
-  "signedTx": {
-    "sig": {
-      "algo": "vega/ed25519",
-      "sig": "6nFF/38QjNdHpaNIk6OvMnrDWnEzrRzl+88gnkME+TBVb2mIbNiHEwPz26z1WUK6E5nDFRMa6FqG71PuOM25Bw==",
-      "version": 1
+    "inputData": "CNjKor2IwsPm4wEQ94EMyj6NAQoQMDc2QkI4NkE1QUE0MU ... k3NjVmYTJlMDI1YzVjNTQxYmE2Nzg5NzAxMzM5ODcyMjBkY2JiOGU1ODJkMWI1YWQyLWNiNGZmZDI5LTdlNGEtNGE2OS04ODYyLThmMGM4NTAzZWJlYQ==",
+    "pubKey": "7c03c4965a46799765fa2e025c5c541bh342970133987220dcbb8e582d1b5ad2",
+    "signature": {
+        "algo": "vega/ed25519",
+        "value": "c8c62d125940875ff3675b3e2c6e86db24199f3e0b78fe ... b6772ef1dc04b9c401766015dfc151bb06b0029dff0e",
+        "version": 1
     },
-    "tx": "CsMBNzYwMWUxMjUtYzZiMC00ZGRjLWIzZTQtMGU2YmE ... QELfsftyQ=="
-  }
+    "version": 1
 }
 # Note: some fields have been shortened to improve readability
 ### :example_sign_tx_response__
 
 
-### __example_prepare_amend_order_response:
-# Response for preparing an amend order message
-{
-  "blob": "MWY5MjViYzMtNjFhMi00YzNiLTg5ZmEtMGJlNDZkYmRhZTQwQgoW ... KOf//////////wE4AQ==",
-}
-# Note: some fields have been shortened to improve readability
-### :example_prepare_amend_order_response__
-
-
 ### __example_sign_tx_amend_response:
-# Response for signing the prepared transaction
+# Response for signing the transaction
 {
-  "base64Bundle": "CuIBCrIBMWY5MjViYzMtNjFhMi00YzNiLTg5ZmEtMGJlNDZkY ... QAIEgx2ZWdhL2VkMjU1MTkYAQ==",
-  "hexBundle": "0ae2010ab20131663932356263332d363161322d3463336 ... 823766567612f656432353531391801",
-  "signedTx": {
-    "sig": {
-      "algo": "vega/ed25519",
-      "sig": "0jsqbLcBc4nT4Y4u3OikFGxrmKWUKTLaOPo/zbbMiROJsAzVEXNgLTPhlmKdDA4BQViZSVdgqXvvVCZQC8kACA==",
-      "version": 1
+    "inputData": "CNjKor2IwsPm4wEQ94EMyj6NAQoQMDc2QkI4NkE1QUE0MU ... k3NjVmYTJlMDI1YzVjNTQxYmE2Nzg5NzAxMzM5ODcyMjBkY2JiOGU1ODJkMWI1YWQyLWNiNGZmZDI5LTdlNGEtNGE2OS04ODYyLThmMGM4NTAzZWJlYQ==",
+    "pubKey": "7c03c4965a46799765fa2e025c5c541bh342970133987220dcbb8e582d1b5ad2",
+    "signature": {
+        "algo": "vega/ed25519",
+        "value": "c8c62d125940875ff3675b3e2c6e86db24199f3e0b78fe ... b6772ef1dc04b9c401766015dfc151bb06b0029dff0e",
+        "version": 1
     },
-    "tx": "CrIBMWY5MjViYzMtNjFhMi00YzNiLTg5ZmEtMGJlNDZkYmRhZTQ ... QELfsftyQ=="
-  }
+    "version": 1
 }
 # Note: some fields have been shortened to improve readability
 ### :example_sign_tx_amend_response__
 
 
-### __example_prepare_cancel_order_response:
-# Response for preparing a cancel order message
-{
-  "blob": "XY2ddEdd2dpYzktYTU5OC00MmNmLTk4ZmMtOTA1NWY0MWUzMTBmQB ... mItZjA4NDllOTY1YzIy",
-}
-# Note: some fields have been shortened to improve readability
-### :example_prepare_cancel_order_response__
-
-
 ### __example_sign_tx_cancel_response:
 # Response for signing the prepared transaction
 {
-  "base64Bundle": "CtEBCqEBNGRjMzA3OWEtZjhhZi00O3NGMtODU4ZmN ... mWJBhIMdmVnYS9lZDI1NTE5GAE=",
-  "hexBundle": "0ad1010aa10134646333303739612d663861662d34 ... 658906120c7665676123432353531391801",
-  "signedTx": {
-    "sig": {
-      "algo": "vega/ed25519",
-      "sig": "qYYL3pTCZLY6sNzowTUwUx8d8iPGn9Vw4jz9nUrfChGAydFcF2aDG5gGZq+FYyExkPo9TcKJ9Uz2X/g0/mWJBg==",
-      "version": 1
+    "inputData": "CNjKor2IwsPm4wEQ94EMyj6NAQoQMDc2QkI4NkE1QUE0MU ... k3NjVmYTJlMDI1YzVjNTQxYmE2Nzg5NzAxMzM5ODcyMjBkY2JiOGU1ODJkMWI1YWQyLWNiNGZmZDI5LTdlNGEtNGE2OS04ODYyLThmMGM4NTAzZWJlYQ==",
+    "pubKey": "7c03c4965a46799765fa2e025c5c541bh342970133987220dcbb8e582d1b5ad2",
+    "signature": {
+        "algo": "vega/ed25519",
+        "value": "c8c62d125940875ff3675b3e2c6e86db24199f3e0b78fe ... b6772ef1dc04b9c401766015dfc151bb06b0029dff0e",
+        "version": 1
     },
-    "tx": "CqEBNGRjMzA3OWEtZjhhZi00OGQzLTg3NGMtODGNZwPb+dYK ... 3ZC37H7ck="
-  }
+    "version": 1
 }
 # Note: some fields have been shortened to improve readability
 ### :example_sign_tx_cancel_response__

--- a/submit-amend-cancel-orders/submit-amend-cancel-orders.sh
+++ b/submit-amend-cancel-orders/submit-amend-cancel-orders.sh
@@ -91,9 +91,6 @@ echo "Blockchain time: $expiresAt"
 # Compose your submit order command, with desired deal ticket information
 # Set your own user specific reference to find the order in next step and
 # as a foreign key to your local client/trading application
-
-# Set your own user specific reference to find the order in next step and
-# as a foreign key to your local client/trading application
 orderRef=$pubKey-$(shuf -i 11111111-99999999 -n 1)-$(shuf -i 1111-9999 -n 1)-$(shuf -i 111111111111-999999999999 -n 1)
 
 # Note: price is an integer. For example 123456 is a price of 1.23456,

--- a/submit-amend-pegged-order/submit-amend-pegged-order-with-Vega-API-client.py
+++ b/submit-amend-pegged-order/submit-amend-pegged-order-with-Vega-API-client.py
@@ -21,12 +21,18 @@ Apps/Libraries:
 # :something__
 #
 
-import base64
-import helpers
-import time
-import os
+# Needed to convert protobuf message to string/json dict for wallet signing
+from google.protobuf.json_format import MessageToDict
 
 from google.protobuf.wrappers_pb2 import Int64Value
+
+import base64
+import helpers
+import requests
+import time
+import os
+import uuid
+
 
 node_url_grpc = os.getenv("NODE_URL_GRPC")
 if not helpers.check_var(node_url_grpc):
@@ -57,7 +63,6 @@ import vegaapiclient as vac
 # Vega gRPC clients for reading/writing data
 data_client = vac.VegaTradingDataClient(node_url_grpc)
 trading_client = vac.VegaTradingClient(node_url_grpc)
-wallet_client = vac.WalletClient(wallet_server_url)
 # :import_client__
 
 #####################################################################################
@@ -68,16 +73,19 @@ print(f"Logging into wallet: {wallet_name}")
 
 # __login_wallet:
 # Log in to an existing wallet
-response = wallet_client.login(wallet_name, wallet_passphrase)
+req = {"wallet": wallet_name, "passphrase": wallet_passphrase}
+response = requests.post(f"{wallet_server_url}/api/v1/auth/token", json=req)
 helpers.check_response(response)
-# Note: secret wallet token is stored internally for duration of session
+token = response.json()["token"]
 # :login_wallet__
 
+assert token != ""
 print("Logged in to wallet successfully")
 
 # __get_pubkey:
 # List key pairs and select public key to use
-response = wallet_client.listkeys()
+headers = {"Authorization": f"Bearer {token}"}
+response = requests.get(f"{wallet_server_url}/api/v1/keys", headers=headers)
 helpers.check_response(response)
 keys = response.json()["keys"]
 pubkey = keys[0]["pub"]
@@ -117,34 +125,36 @@ print(f"Blockchain time: {blockchain_time}")
 #####################################################################################
 
 # __prepare_submit_pegged_order:
-# Prepare a submit order message with a pegged BUY order
-order = vac.api.trading.PrepareSubmitOrderRequest(
-    submission=vac.commands.v1.commands.OrderSubmission(
-        market_id=marketID,
-        side=vac.vega.Side.SIDE_BUY,
-        size=50,
-        expires_at=expiresAt,
-        time_in_force=vac.vega.Order.TimeInForce.TIME_IN_FORCE_GTT,
-        type=vac.vega.Order.Type.TYPE_LIMIT,
-        pegged_order=vac.vega.PeggedOrder(
-            offset=-5,
-            reference=vac.vega.PEGGED_REFERENCE_MID
-        )
-    )
+# Compose your submit order command with a pegged BUY order
+# Set your own user specific reference to find the order in next step and
+# as a foreign key to your local client/trading application
+order_ref = f"{pubkey}-{uuid.uuid4()}"
+order_data = vac.commands.v1.commands.OrderSubmission(
+    market_id=marketID,
+    side=vac.vega.Side.SIDE_BUY,
+    size=50,
+    expires_at=expiresAt,
+    time_in_force=vac.vega.Order.TimeInForce.TIME_IN_FORCE_GTT,
+    type=vac.vega.Order.Type.TYPE_LIMIT,
+    pegged_order=vac.vega.PeggedOrder(
+        offset=-5,
+        reference=vac.vega.PEGGED_REFERENCE_MID
+    ),
+    reference=order_ref
 )
-prepared_order = trading_client.PrepareSubmitOrder(order)
 # :prepare_submit_pegged_order__
 
-order_ref = prepared_order.submit_id
-print(f"Prepared pegged order, ref: {order_ref}")
-
 # __sign_tx_pegged_order:
-# Sign the prepared pegged order transaction
-# Note: Setting propagate to true will submit to a Vega node
-blob_base64 = base64.b64encode(prepared_order.blob).decode("ascii")
-response = wallet_client.signtx(blob_base64, pubkey, True)
+# Sign the transaction with an order submission command
+# Note: Setting propagate to true will also submit to a Vega node
+submission = {
+    "orderSubmission": MessageToDict(order_data),
+    "pubKey": pubkey,
+    "propagate": True
+}
+url = f"{wallet_server_url}/api/v1/command/sync"
+response = requests.post(url, headers=headers, json=submission)
 helpers.check_response(response)
-signedTx = response.json()["signedTx"]
 # :sign_tx_pegged_order__
 
 print("Signed pegged order and sent to Vega")
@@ -171,8 +181,8 @@ else:
 #####################################################################################
 
 # __prepare_amend_pegged_order:
-# Prepare the amend pegged order message
-amend = vac.commands.v1.commands.OrderAmendment(
+# Compose your amend order command, with changes to your existing order
+amend_data = vac.commands.v1.commands.OrderAmendment(
     market_id=marketID,
     order_id=orderID,
     size_delta=-25,
@@ -180,17 +190,20 @@ amend = vac.commands.v1.commands.OrderAmendment(
     pegged_reference=vac.vega.PEGGED_REFERENCE_BEST_BID,
     pegged_offset=Int64Value(value=-100)
 )
-order = vac.api.trading.PrepareAmendOrderRequest(amendment=amend)
-prepared_order = trading_client.PrepareAmendOrder(order)
-blob_base64 = base64.b64encode(prepared_order.blob).decode("ascii")
 # :prepare_amend_pegged_order__
 
 print(f"Amendment prepared for order ID: {orderID}")
 
 # __sign_tx_pegged_amend:
-# Sign the prepared pegged order transaction for amendment
+# Sign the prepared order transaction with an order amendment command
 # Note: Setting propagate to true will also submit to a Vega node
-response = wallet_client.signtx(blob_base64, pubkey, True)
+amendment = {
+    "orderAmendment": MessageToDict(amend_data),
+    "pubKey": pubkey,
+    "propagate": True
+}
+url = f"{wallet_server_url}/api/v1/command/sync"
+response = requests.post(url, headers=headers, json=amendment)
 helpers.check_response(response)
 # :sign_tx_pegged_amend__
 

--- a/submit-liquidity-provision/response-examples.txt
+++ b/submit-liquidity-provision/response-examples.txt
@@ -1,12 +1,3 @@
-### __example_prepare_liquidity_order_response:
-# Response for preparing a liquidity submission message
-{
-  "blob": "YWQ5M2NmYzktYTU5OC00MmNmLTk4ZmMtOTA1NWY0MWUzMTBmQBI ... mItZjA4NDllOTY1YzIy",
-}
-# Note: some fields have been shortened to improve readability
-### :example_prepare_liquidity_order_response__
-
-
 ### __example_sign_tx_liquidity_response:
 # Response for signing the prepared transaction
 {

--- a/submit-liquidity-provision/submit-liquidity-provision-order.py
+++ b/submit-liquidity-provision/submit-liquidity-provision-order.py
@@ -118,9 +118,9 @@ print("Liquidity provisions:\n{}".format(json.dumps(response_json, indent=2, sor
 # for a market which is configured to have a precision of 5 decimal places.
 
 # __prepare_liquidity_order:
-# Prepare a liquidity commitment transaction message
-req = {
-    "submission": {
+# Compose your submit liquidity provision command
+submission = {
+    "liquidityProvisionSubmission": {
         "marketId": marketID,
         "commitmentAmount": "100",
         "fee": "0.01",
@@ -153,23 +153,19 @@ req = {
                 "reference": "PEGGED_REFERENCE_MID"
             }
         ]
-    }
+    },
+    "pubKey": pubkey,
+    "propagate": True
 }
-url = f"{node_url_rest}/liquidity-provisions/prepare/submit"
-response = requests.post(url, json=req)
-helpers.check_response(response)
-prepared_order = response.json()
 # :prepare_liquidity_order__
 
-print(f"Prepared liquidity commitment for market: {marketID} {marketName}")
+print("Liquidity provision submission: ", submission)
 
 # __sign_tx_liquidity_order:
-# Sign the prepared liquidity commitment transaction
+# Sign the transaction with a liquidity provision submission command
 # Note: Setting propagate to true will also submit to a Vega node
-blob = prepared_order["blob"]
-req = {"tx": blob, "pubKey": pubkey, "propagate": True}
-url = f"{wallet_server_url}/api/v1/messages"
-response = requests.post(url, headers=headers, json=req)
+url = f"{wallet_server_url}/api/v1/command/sync"
+response = requests.post(url, headers=headers, json=submission)
 helpers.check_response(response)
 # :sign_tx_liquidity_order__
 
@@ -184,10 +180,11 @@ exit(0)
 #####################################################################################
 
 # __amend_liquidity_order:
-# Prepare a liquidity commitment order message (it will now serve as an amendment request): modify fields to be amended
-
-req = {
-    "submission": {
+# Compose a liquidity commitment order message
+# (it will now serve as an amendment request):
+# modify fields you want to be amended
+submission = {
+    "liquidityProvisionSubmission": {
         "marketId": marketID,
         "commitmentAmount": "500",
         "fee": "0.005",
@@ -205,22 +202,18 @@ req = {
                 "reference": "PEGGED_REFERENCE_MID"
             }
         ]
-    }
+    },
+    "pubKey": pubkey,
+    "propagate": True
 }
-url = f"{node_url_rest}/liquidity-provisions/prepare/submit"
-response = requests.post(url, json=req)
-helpers.check_response(response)
-prepared_order = response.json()
 # :amend_liquidity_order__
 
-print(f"Prepared liquidity commitment (amendment) for market: {marketID} {marketName}")
+print("Liquidity provision amendment: ", submission)
 
-# Sign the prepared liquidity commitment transaction
+# Sign the transaction with a liquidity provision submission command
 # Note: Setting propagate to true will also submit to a Vega node
-blob = prepared_order["blob"]
-req = {"tx": blob, "pubKey": pubkey, "propagate": True}
-url = f"{wallet_server_url}/api/v1/messages"
-response = requests.post(url, headers=headers, json=req)
+url = f"{wallet_server_url}/api/v1/command/sync"
+response = requests.post(url, headers=headers, json=submission)
 helpers.check_response(response)
 
 print("Signed liquidity commitment (amendment) and sent to Vega")
@@ -234,31 +227,26 @@ time.sleep(10)
 #####################################################################################
 
 # __cancel_liquidity_order:
-
-# Prepare a liquidity commitment order message (it will now serve as a cancellation request): set commitmentAmount to 0, 
+# Compose a liquidity commitment order message
+# (it will now serve as a cancellation request): set commitmentAmount to 0,
 # note that transaction may get rejected if removing previously supplied liquidity 
 # will result in insufficient liquidity for the market
-
-req = {
-    "submission": {
+submission = {
+    "liquidityProvisionSubmission": {
         "marketId": marketID,
         "commitmentAmount": "0"
-    }
+    },
+    "pubKey": pubkey,
+    "propagate": True
 }
-url = f"{node_url_rest}/liquidity-provisions/prepare/submit"
-response = requests.post(url, json=req)
-helpers.check_response(response)
-prepared_order = response.json()
 # :cancel_liquidity_order__
 
-print(f"Prepared liquidity commitment (cancellation) for market: {marketID} {marketName}")
+print("Liquidity provision cancellation: ", submission)
 
-# Sign the prepared liquidity commitment transaction
+# Sign the transaction with a liquidity provision submission command
 # Note: Setting propagate to true will also submit to a Vega node
-blob = prepared_order["blob"]
-req = {"tx": blob, "pubKey": pubkey, "propagate": True}
-url = f"{wallet_server_url}/api/v1/messages"
-response = requests.post(url, headers=headers, json=req)
+url = f"{wallet_server_url}/api/v1/command/sync"
+response = requests.post(url, headers=headers, json=submission)
 helpers.check_response(response)
 
 print("Signed liquidity commitment (cancellation) and sent to Vega")

--- a/submit-liquidity-provision/submit-liquidity-provision-order.py
+++ b/submit-liquidity-provision/submit-liquidity-provision-order.py
@@ -162,7 +162,7 @@ submission = {
 print("Liquidity provision submission: ", submission)
 
 # __sign_tx_liquidity_order:
-# Sign the transaction with a liquidity provision submission command
+# Sign the transaction with a liquidity provision submission
 # Note: Setting propagate to true will also submit to a Vega node
 url = f"{wallet_server_url}/api/v1/command/sync"
 response = requests.post(url, headers=headers, json=submission)
@@ -172,7 +172,7 @@ helpers.check_response(response)
 print("Signed liquidity commitment and sent to Vega")
 
 # Comment out the lines below to add a cancellation of the newly created LP commitment
-print("To add cancellation step, uncomment line 180 of the script file")
+print("To add amend/cancellation step, comment line 176 of the script file")
 exit(0)
 
 #####################################################################################

--- a/submit-order/submit-order.py
+++ b/submit-order/submit-order.py
@@ -127,23 +127,22 @@ submission = {
 # __sign_tx:
 # Wallet server: Sign the order submission message
 # Sign the transaction with a pegged order submission command
-# Note: Setting propagate to true will also submit to a Vega node
 url = f"{walletserver_url}/api/v1/command/sync"
 response = requests.post(url, headers=headers, json=submission)
 helpers.check_response(response)
 print(response.json())
 signedTx = response.json()["signature"]
-inputData = response.json()["inputData"]
 # :sign_tx__
 print("Response from SignTransaction:")
 print(json.dumps(signedTx, indent=2, sort_keys=True))
 
 # __submit_tx:
 # Vega node: Submit the signed transaction
+# Todo: update this when the v2 submit transaction endpoints exist
 req = {
     "tx": {
         "sig": signedTx,
-        "tx": inputData
+        "tx": ""
     },
     "type": "TYPE_SYNC"
 }

--- a/submit-order/submit-order.py
+++ b/submit-order/submit-order.py
@@ -133,13 +133,20 @@ response = requests.post(url, headers=headers, json=submission)
 helpers.check_response(response)
 print(response.json())
 signedTx = response.json()["signature"]
+inputData = response.json()["inputData"]
 # :sign_tx__
 print("Response from SignTransaction:")
 print(json.dumps(signedTx, indent=2, sort_keys=True))
 
 # __submit_tx:
 # Vega node: Submit the signed transaction
-req = {"tx": signedTx}
+req = {
+    "tx": {
+        "sig": signedTx,
+        "tx": inputData
+    },
+    "type": "TYPE_SYNC"
+}
 print("Request for SubmitTransaction:")
 print(json.dumps(req, indent=2, sort_keys=True))
 url = f"{node_url_rest}/transaction"

--- a/submit-order/submit-order.py
+++ b/submit-order/submit-order.py
@@ -103,49 +103,51 @@ marketID = response.json()["markets"][0]["id"]
 # :get_market__
 
 # __prepare_order:
-# Next, create an order submission
+# Next, prepare a SubmitOrder
 response = requests.get(f"{node_url_rest}/time")
 helpers.check_response(response)
 blockchaintime = int(response.json()["timestamp"])
 expiresAt = str(int(blockchaintime + 120 * 1e9))  # expire in 2 minutes
 
-submission = {
-    "orderSubmission": {
+req = {
+    "submission": {
         "marketId": marketID,
+        "partyId": pubKey,
         "price": "100000",  # Note: price is an integer. For example 123456
         "size": "100",  # is a price of 1.23456, assuming 5 decimal places.
         "side": "SIDE_BUY",
         "timeInForce": "TIME_IN_FORCE_GTT",
         "expiresAt": expiresAt,
         "type": "TYPE_LIMIT",
-    },
-    "pubKey": pubKey,
-    "propagate": False
+    }
 }
+print("Request for PrepareSubmitOrder:")
+print(json.dumps(req, indent=2, sort_keys=True))
+url = f"{node_url_rest}/orders/prepare/submit"
+response = requests.post(url, json=req)
+helpers.check_response(response)
+preparedOrder = response.json()
 # :prepare_order__
+print("Response from PrepareSubmitOrder:")
+print(json.dumps(preparedOrder, indent=2, sort_keys=True))
 
 # __sign_tx:
-# Wallet server: Sign the order submission message
-# Sign the transaction with a pegged order submission command
-url = f"{walletserver_url}/api/v1/command/sync"
-response = requests.post(url, headers=headers, json=submission)
+# Wallet server: Sign the prepared transaction
+blob = preparedOrder["blob"]
+req = {"tx": blob, "pubKey": pubKey, "propagate": False}
+print("Request for SignTx:")
+print(json.dumps(req, indent=2, sort_keys=True))
+url = f"{walletserver_url}/api/v1/messages"
+response = requests.post(url, headers=headers, json=req)
 helpers.check_response(response)
-print(response.json())
-signedTx = response.json()["signature"]
+signedTx = response.json()["signedTx"]
 # :sign_tx__
-print("Response from SignTransaction:")
+print("Response from SignTx:")
 print(json.dumps(signedTx, indent=2, sort_keys=True))
 
 # __submit_tx:
 # Vega node: Submit the signed transaction
-# Todo: update this when the v2 submit transaction endpoints exist
-req = {
-    "tx": {
-        "sig": signedTx,
-        "tx": ""
-    },
-    "type": "TYPE_SYNC"
-}
+req = {"tx": signedTx}
 print("Request for SubmitTransaction:")
 print(json.dumps(req, indent=2, sort_keys=True))
 url = f"{node_url_rest}/transaction"

--- a/submit-order/submit-order.py
+++ b/submit-order/submit-order.py
@@ -125,15 +125,16 @@ submission = {
 # :prepare_order__
 
 # __sign_tx:
-# Wallet server: Sign the prepared transaction
+# Wallet server: Sign the order submission message
 # Sign the transaction with a pegged order submission command
 # Note: Setting propagate to true will also submit to a Vega node
 url = f"{walletserver_url}/api/v1/command/sync"
 response = requests.post(url, headers=headers, json=submission)
 helpers.check_response(response)
-signedTx = response.json()["signedTx"]
+print(response.json())
+signedTx = response.json()["signature"]
 # :sign_tx__
-print("Response from SignTx:")
+print("Response from SignTransaction:")
 print(json.dumps(signedTx, indent=2, sort_keys=True))
 
 # __submit_tx:

--- a/submit-order/submit-order.py
+++ b/submit-order/submit-order.py
@@ -103,42 +103,33 @@ marketID = response.json()["markets"][0]["id"]
 # :get_market__
 
 # __prepare_order:
-# Next, prepare a SubmitOrder
+# Next, create an order submission
 response = requests.get(f"{node_url_rest}/time")
 helpers.check_response(response)
 blockchaintime = int(response.json()["timestamp"])
 expiresAt = str(int(blockchaintime + 120 * 1e9))  # expire in 2 minutes
 
-req = {
-    "submission": {
+submission = {
+    "orderSubmission": {
         "marketId": marketID,
-        "partyId": pubKey,
         "price": "100000",  # Note: price is an integer. For example 123456
         "size": "100",  # is a price of 1.23456, assuming 5 decimal places.
         "side": "SIDE_BUY",
         "timeInForce": "TIME_IN_FORCE_GTT",
         "expiresAt": expiresAt,
         "type": "TYPE_LIMIT",
-    }
+    },
+    "pubKey": pubKey,
+    "propagate": False
 }
-print("Request for PrepareSubmitOrder:")
-print(json.dumps(req, indent=2, sort_keys=True))
-url = f"{node_url_rest}/orders/prepare/submit"
-response = requests.post(url, json=req)
-helpers.check_response(response)
-preparedOrder = response.json()
 # :prepare_order__
-print("Response from PrepareSubmitOrder:")
-print(json.dumps(preparedOrder, indent=2, sort_keys=True))
 
 # __sign_tx:
 # Wallet server: Sign the prepared transaction
-blob = preparedOrder["blob"]
-req = {"tx": blob, "pubKey": pubKey, "propagate": False}
-print("Request for SignTx:")
-print(json.dumps(req, indent=2, sort_keys=True))
-url = f"{walletserver_url}/api/v1/messages"
-response = requests.post(url, headers=headers, json=req)
+# Sign the transaction with a pegged order submission command
+# Note: Setting propagate to true will also submit to a Vega node
+url = f"{walletserver_url}/api/v1/command/sync"
+response = requests.post(url, headers=headers, json=submission)
 helpers.check_response(response)
 signedTx = response.json()["signedTx"]
 # :sign_tx__


### PR DESCRIPTION
Closes #84 

Note: 

1 - All Golang examples remain with prepare, will be converted in the `api` repo along with updates there
2 - The two step sign and submit sample (submit-order) needs to stay with prepare for now until core releases the updated v2 transaction endpoint on the Vega node