### PR TITLE
API urls update for 0.54

### DIFF
--- a/credentials-template
+++ b/credentials-template
@@ -6,9 +6,9 @@ WALLET_PASSPHRASE="example_wallet_passphrase"
 VEGA_MARKET="marketID"
 
 WALLETSERVER_URL="https://wallet.testnet.vega.xyz"
-NODE_URL_REST="https://lb.testnet.vega.xyz/datanode/rest"
-NODE_URL_GRAPHQL="https://lb.testnet.vega.xyz/datanode/gql/query"
-NODE_URL_GRPC="n06.testnet.vega.xyz:3007"
+NODE_URL_REST="https://api.n10.testnet.vega.xyz"
+NODE_URL_GRAPHQL="https://api.n10.testnet.vega.xyz/graphql"
+NODE_URL_GRPC="api.n10.testnet.vega.xyz:3007"
 
 # Do not edit below this line:
 PYTHONPATH=.

--- a/credentials-win-template
+++ b/credentials-win-template
@@ -1,9 +1,9 @@
 WALLET_NAME=example_wallet_name
 WALLET_PASSPHRASE=example_wallet_passphrase
 WALLETSERVER_URL=https://wallet.testnet.vega.xyz
-NODE_URL_REST=https://lb.testnet.vega.xyz/datanode/rest
-NODE_URL_GRAPHQL=https://lb.testnet.vega.xyz/datanode/gql/query
-NODE_URL_GRPC=n06.testnet.vega.xyz:3002
+NODE_URL_REST=https://api.n10.testnet.vega.xyz
+NODE_URL_GRAPHQL=https://api.10.testnet.vega.xyz/graphql
+NODE_URL_GRPC=api.n10.testnet.vega.xyz:3007
 PYTHONPATH=.
 VEGA_MARKET=marketID
 


### PR DESCRIPTION
Updates the URLs in the credentials templates files to match the URLs
that we have switched to in core v0.54

- Update credentials-template GraphQL, REST, GRPC urls
- Update credentials-win-template GraphQL, REST, GRPC urls

For some of [the 0.54 update review](https://github.com/vegaprotocol/sample-api-scripts/issues?q=is%3Aissue+is%3Aopen+%2254%22+) this will be enough to get them working again.
